### PR TITLE
Save only live cells, change concept

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "golr"
 version = "0.1.0"
 dependencies = [
  "docopt 0.6.63 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -15,6 +16,11 @@ dependencies = [
  "regex 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ authors = [
 rand = "0.3"
 rustc-serialize = "*"
 docopt = "*"
+itertools = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,15 @@
 extern crate rustc_serialize;
 extern crate docopt;
+extern crate rand;
+extern crate itertools;
 
 mod display;
 mod world;
 
 use docopt::Docopt;
 use std::thread::sleep_ms;
+
+use world::World;
 
 static USAGE: &'static str = "
 Usage:
@@ -27,14 +31,9 @@ struct CliArgs {
 fn main() {
     let args = Docopt::new(USAGE).and_then(|d| d.decode::<CliArgs>())
                                  .unwrap_or_else(|e| e.exit());
-
-    let mut world = world::World::new(args.flag_width, args.flag_height);
-
-    world.randomize();
-
+    let mut world = World::new(args.flag_width, args.flag_height).seed();
     loop {
-        world = world.evolve();
-        println!("\x1b[2J\n{}", world);
+        println!("\x1b[2J\n{}", world.evolve());
         std::thread::sleep_ms(args.flag_fps);
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use rand::random;
 
-pub type Point = (isize, isize);
+type Point = (isize, isize);
 
 #[derive(Debug, Clone)]
 pub struct World {
@@ -50,11 +50,11 @@ impl World {
         }
     }
 
-    fn decide_fate(&self) -> bool {
-        if self.generation.contains(n) {
-            *c == 3 || *c == 2
+    fn decide_fate(&self, p: &Point, c: usize) -> bool {
+        if self.generation.contains(p) {
+            c == 3 || c == 2
         } else {
-            *c == 3
+            c == 3
         }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -30,9 +30,9 @@ impl World {
 
     pub fn evolve(&mut self) -> &World {
         self.generation = self.neighbours.iter()
-            .filter(|&(n, c)| if self.generation.contains(n) { *c == 3 || *c == 2 } else { *c == 3 })
-            .map(|(n, _)| *n)
-            .collect::<HashSet<Point>>();
+                              .filter(|&(n, c)| self.decide_fate(n, *c))
+                              .map(|(n, _)| *n)
+                              .collect::<HashSet<Point>>();
         self.calculate_neighbours();
         self.age += 1;
         self
@@ -45,9 +45,16 @@ impl World {
                                     .filter(|&(dx, dy)| dx != 0 || dy != 0)
                                     .map(|(dx, dy)| (dx + x, dy + y));
             for n in neighbours {
-                let counts = self.neighbours.entry(n).or_insert(0);
-                *counts = *counts + 1;
+                *self.neighbours.entry(n).or_insert(0) += 1;
             }
+        }
+    }
+
+    fn decide_fate(&self) -> bool {
+        if self.generation.contains(n) {
+            *c == 3 || *c == 2
+        } else {
+            *c == 3
         }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use rand::random;
 
@@ -9,25 +9,26 @@ pub type Point = (isize, isize);
 pub struct World {
     width: isize,
     height: isize,
-    generation: Vec<Point>,
+    generation: HashSet<Point>,
     age: usize,
 }
 
 impl World {
     pub fn new(width: isize, height: isize)  -> World {
-        World { width: width, height: height, age: 0, generation: vec![] }
+        World { width: width, height: height, age: 0,
+                generation: HashSet::new() }
     }
 
     pub fn seed(mut self) -> World {
         self.generation = (0..self.width).cartesian_product(0..self.height)
             .filter(|_| random())
-            .collect::<Vec<Point>>();
+            .collect::<HashSet<Point>>();
         self
     }
 
     pub fn evolve(&mut self) -> &World {
         let mut neighbours_counts = HashMap::new();
-        for &(x, y) in &self.generation[..] {
+        for &(x, y) in self.generation.iter() {
             let neighbours = (-1..2).cartesian_product(-1..2)
                                     .filter(|&(dx, dy)| dx != 0 || dy != 0)
                                     .map(|(dx, dy)| (dx + x, dy + y));
@@ -39,7 +40,7 @@ impl World {
         self.generation = neighbours_counts.iter()
             .filter(|&(n, c)| if self.generation.contains(n) { *c == 3 || *c == 2 } else { *c == 3 })
             .map(|(n, _)| *n)
-            .collect::<Vec<Point>>();
+            .collect::<HashSet<Point>>();
         self.age += 1;
         self
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -16,8 +16,7 @@ pub struct World {
 
 impl World {
     pub fn new(width: isize, height: isize)  -> World {
-        World { width: width, height: height, age: 0,
-                generation: HashSet::with_capacity((width * height) as usize),
+        World { width: width, height: height, age: 0, generation: HashSet::new(),
                 neighbours: HashMap::with_capacity((width * height * 8) as usize) }
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -22,8 +22,8 @@ impl World {
 
     pub fn seed(mut self) -> World {
         self.generation = (0..self.width).cartesian_product(0..self.height)
-            .filter(|_| random())
-            .collect::<HashSet<Point>>();
+                                         .filter(|_| random())
+                                         .collect::<HashSet<Point>>();
         self.calculate_neighbours();
         self
     }

--- a/src/world.rs
+++ b/src/world.rs
@@ -47,7 +47,7 @@ impl World {
 
 impl fmt::Display for World {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf = String::new();
+        let mut buf = String::with_capacity(((self.width + 2) * (self.height + 2) + 50) as usize);
         for x in 0..self.width + 2 {
             buf.push(if x == 0 { '┌' } else if x == self.width + 1 { '┐' } else { '─' });
         }


### PR DESCRIPTION
Add itertools as dependency for cartesian_product iterator adaptor
Replace explicit CellState type with plain boolean value
Store only live cells coordinates as generation
Store number of generations as age of the World
Remove get_sibling_coords, decide_fate, is_alive and set_state World methods
Implement seed function for initial population of the World
Implement evolve function in more functional style
Show number of live cells and age of the World
Allocate buffer with capacity enough to keep cli representation of the world
Improve lookup performance using HashSet instead of Vec
Store neighbours map to eliminate allocation
Bring back decide_fate method with slightly different semantic
